### PR TITLE
Wrapping all titlenode values with htmlspecialchars

### DIFF
--- a/OAIMetadataFormat_JATS.inc.php
+++ b/OAIMetadataFormat_JATS.inc.php
@@ -232,7 +232,7 @@ class OAIMetadataFormat_JATS extends OAIMetadataFormat {
 			foreach ($issue->getTitle(null) as $locale => $title) {
 				if (empty($title)) continue;
 				$titleNode = $this->_addChildInOrder($articleMetaNode, $doc->createElement('issue-title'));
-				$titleNode->nodeValue = $title;
+				$titleNode->nodeValue = htmlspecialchars($title);
 				$titleNode->setAttribute('xml:lang', substr($locale,0,2));
 			}
 		}
@@ -243,11 +243,11 @@ class OAIMetadataFormat_JATS extends OAIMetadataFormat {
 		while ($titleGroupNode->hasChildNodes()) $titleGroupNode->removeChild($titleGroupNode->firstChild);
 		$titleNode = $titleGroupNode->appendChild($doc->createElement('article-title'));
 		$titleNode->setAttribute('xml:lang', substr($article->getLocale(),0,2));
-		$titleNode->nodeValue = $article->getTitle($article->getLocale());
+		$titleNode->nodeValue = htmlspecialchars($article->getTitle($article->getLocale()));
 		if (!empty($subtitle = $article->getSubtitle($article->getLocale()))) {
 			$subtitleNode = $titleGroupNode->appendChild($doc->createElement('subtitle'));
 			$subtitleNode->setAttribute('xml:lang', substr($article->getLocale(),0,2));
-			$subtitleNode->nodeValue = $subtitle;
+			$subtitleNode->nodeValue = htmlspecialchars($subtitle);
 		}
 		foreach ($article->getTitle(null) as $locale => $title) {
 			if ($locale == $article->getLocale()) continue;
@@ -255,10 +255,10 @@ class OAIMetadataFormat_JATS extends OAIMetadataFormat {
 			$transTitleGroupNode = $titleGroupNode->appendChild($doc->createElement('trans-title-group'));
 			$transTitleGroupNode->setAttribute('xml:lang', substr($locale,0,2));
 			$titleNode = $transTitleGroupNode->appendChild($doc->createElement('trans-title'));
-			$titleNode->nodeValue = $title;
+			$titleNode->nodeValue = htmlspecialchars($title);
 			if (!empty($subtitle = $article->getSubtitle($locale))) {
 				$subtitleNode = $transTitleGroupNode->appendChild($doc->createElement('trans-subtitle'));
-				$subtitleNode->nodeValue = $subtitle;
+				$subtitleNode->nodeValue = htmlspecialchars($subtitle);
 			}
 		}
 

--- a/OAIMetadataFormat_JATS.inc.php
+++ b/OAIMetadataFormat_JATS.inc.php
@@ -232,7 +232,8 @@ class OAIMetadataFormat_JATS extends OAIMetadataFormat {
 			foreach ($issue->getTitle(null) as $locale => $title) {
 				if (empty($title)) continue;
 				$titleNode = $this->_addChildInOrder($articleMetaNode, $doc->createElement('issue-title'));
-				$titleNode->nodeValue = htmlspecialchars($title);
+				$titleText = $doc->createTextNode($title);
+				$titleNode->appendChild($titleText);
 				$titleNode->setAttribute('xml:lang', substr($locale,0,2));
 			}
 		}
@@ -243,11 +244,13 @@ class OAIMetadataFormat_JATS extends OAIMetadataFormat {
 		while ($titleGroupNode->hasChildNodes()) $titleGroupNode->removeChild($titleGroupNode->firstChild);
 		$titleNode = $titleGroupNode->appendChild($doc->createElement('article-title'));
 		$titleNode->setAttribute('xml:lang', substr($article->getLocale(),0,2));
-		$titleNode->nodeValue = htmlspecialchars($article->getTitle($article->getLocale()));
+		$articleTitleText = $doc->createTextNode($article->getTitle($article->getLocale()));
+                $titleNode->appendChild($articleTitleText);
 		if (!empty($subtitle = $article->getSubtitle($article->getLocale()))) {
+			$subtitleText = $doc->createTextNode($subtitle);
 			$subtitleNode = $titleGroupNode->appendChild($doc->createElement('subtitle'));
 			$subtitleNode->setAttribute('xml:lang', substr($article->getLocale(),0,2));
-			$subtitleNode->nodeValue = htmlspecialchars($subtitle);
+			$subtitleNode->appendChild($subtitleText);
 		}
 		foreach ($article->getTitle(null) as $locale => $title) {
 			if ($locale == $article->getLocale()) continue;
@@ -255,10 +258,12 @@ class OAIMetadataFormat_JATS extends OAIMetadataFormat {
 			$transTitleGroupNode = $titleGroupNode->appendChild($doc->createElement('trans-title-group'));
 			$transTitleGroupNode->setAttribute('xml:lang', substr($locale,0,2));
 			$titleNode = $transTitleGroupNode->appendChild($doc->createElement('trans-title'));
-			$titleNode->nodeValue = htmlspecialchars($title);
+			$titleText = $doc->createTextNode($title);
+                        $titleNode->appendChild($titleText);
 			if (!empty($subtitle = $article->getSubtitle($locale))) {
 				$subtitleNode = $transTitleGroupNode->appendChild($doc->createElement('trans-subtitle'));
-				$subtitleNode->nodeValue = htmlspecialchars($subtitle);
+				$subtitleText = $doc->createTextNode($subtitle);
+                                $subtitleNode->appendChild($subtitleText);
 			}
 		}
 


### PR DESCRIPTION
Ampersands in titles cause XML parsing errors. Wrapping the values in htmlspecialchars() fixes the issue on our end. For instance, this is what happens when we try to load JATS: 

`XML Parsing Error: not well-formed
Location: https://jps.library.utoronto.ca/index.php/cpoj/oai?verb=ListRecords&metadataPrefix=jats
Line Number 68, Column 78:
			<issue-id>2003</issue-id><issue-title xml:lang="en">Canadian Prosthetics & Orthotics Journal. 2018; Volume 1, Issue 1.</issue-title><permissions>
--------------------------------------------------------------------------------------------------^`